### PR TITLE
parse all fields of pcd files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,7 @@ find_package(catkin  REQUIRED COMPONENTS pcl_ros)
 find_package(VTK REQUIRED)
 
 catkin_package(
+INCLUDE_DIRS Filters
 )
 
 include(${VTK_USE_FILE})

--- a/Filters/vtkPCLConversions.h
+++ b/Filters/vtkPCLConversions.h
@@ -47,6 +47,8 @@ public:
 
   static vtkSmartPointer<vtkPolyData> PolyDataFromPCDFile(const std::string& filename);
 
+  static vtkSmartPointer<vtkPolyData> ConvertPointCloud2ToVtk(pcl::PCLPointCloud2 &cloud);
+
   static vtkSmartPointer<vtkPolyData> PolyDataFromPointCloud(
     pcl::PointCloud<pcl::PointXYZ>::ConstPtr cloud);
 


### PR DESCRIPTION
@mauricefallon 
Parse all fields of pcd files. It introduces a dependency with vtk_ros, I don't think that it's an issue.
It works with : https://github.com/ori-drs/vtk_ros/pull/13
I tested it with 1_0.pcd from https://drive.google.com/drive/u/0/folders/1yCaNsJjbW3G34KIXoMA6LpwVqB4LxTgx


![Screenshot from 2019-11-11 17-09-22](https://user-images.githubusercontent.com/41473839/68607024-9c817200-04a7-11ea-8f1f-af377797e8ae.png)
